### PR TITLE
Move file access and naming in separate class, improve saving, allow flat file structure

### DIFF
--- a/src/main/python/CalendarFileSelector.py
+++ b/src/main/python/CalendarFileSelector.py
@@ -19,9 +19,6 @@ from __future__ import annotations
 import random
 import typing
 from datetime import date
-import os
-import yaml
-import regex
 from random import randint
 
 from PyQt6 import QtWidgets, QtGui, QtCore
@@ -32,6 +29,7 @@ from ColorParser import *
 import datetime
 from EditPane import EditPane
 from WebView import WebView
+from EntryFile import EntryFile
 
 if typing.TYPE_CHECKING:
     pass
@@ -157,7 +155,8 @@ class CalendarFileSelector(QtWidgets.QCalendarWidget):
 
         pen = painter.pen()
 
-        if not self.file_exists(date.toPyDate()):
+        entry_file = EntryFile(date.toPyDate())
+        if not entry_file.exists():
             painter.fillRect(rect, QtGui.QColor.fromHsl(pen.color().hue(), pen.color().saturation(), pen.color().lightness(), 50))
 
         if (date.month() != self.monthShown()):
@@ -165,7 +164,7 @@ class CalendarFileSelector(QtWidgets.QCalendarWidget):
         elif date.dayOfWeek() == 6 or date.dayOfWeek() == 7:
             painter.setPen(QtGui.QColor("red"))
 
-        tags = self.get_tags_from_date_file(date.toPyDate())
+        tags = entry_file.get_tags()
         rect.adjust(0, 0, -1, -1)
         pen = painter.pen()
         pen.setColor(QtGui.QColor.fromHsl(pen.color().hue(), pen.color().saturation(), pen.color().lightness(), 150))
@@ -200,38 +199,3 @@ class CalendarFileSelector(QtWidgets.QCalendarWidget):
         painter.setBackgroundMode(QtCore.Qt.BGMode.OpaqueMode)
         painter.drawText(rect, QtCore.Qt.AlignmentFlag.AlignBottom | QtCore.Qt.AlignmentFlag.AlignHCenter, text)
         painter.restore()
-
-    def file_exists(self, date: datetime.date) -> bool:
-        """Checks if a file for the given date exists"""
-        formatted_date = date.strftime("%Y-%m-%d")
-
-        # Get folder for today's journal entry
-        config_file = get_resource("config.json")
-        with open(config_file, "r") as file:
-            file_directory = os.path.join(json.loads(file.read())["diary_directory"], str(date.year),
-                                          str(date.month), formatted_date)
-        return os.path.exists(file_directory)
-
-
-    def get_tags_from_date_file(self, date: datetime.date):
-        """Open or create a markdown file corresponding to today"""
-        formatted_date = date.strftime("%Y-%m-%d")
-
-        # Get folder for today's journal entry
-        config_file = get_resource("config.json")
-        with open(config_file, "r") as file:
-            file_directory = os.path.join(json.loads(file.read())["diary_directory"], str(date.year),
-                                          str(date.month), formatted_date)
-
-        try:
-            with open(os.path.join(file_directory, f"{formatted_date}.md"), "r") as file:
-                pattern = regex.compile(r"(?<=(^-{3,}\n)).+?(?=-{3,})", regex.DOTALL)
-                contents = file.read()
-                metadata = regex.search(pattern, contents)
-            if metadata is not None:
-                meta_dict = yaml.safe_load(metadata.group())
-                if "tags" in meta_dict.keys():
-                    return meta_dict["tags"]
-        except Exception:
-            return {}
-

--- a/src/main/python/EditPane.py
+++ b/src/main/python/EditPane.py
@@ -318,7 +318,8 @@ class EditPane(QtWidgets.QTextEdit):
 
         :param event: the QEvent that caused the invocation
         """
-
+        super().leaveEvent(event)
+        self._entry_file.save(self.toPlainText())
         self.verticalScrollBar().setVisible(False)
 
     def insertFromMimeData(self, source: QtCore.QMimeData) -> None:
@@ -338,7 +339,3 @@ class EditPane(QtWidgets.QTextEdit):
         format.setRightMargin(margin_size)
         self.document().rootFrame().frameFormat().setRightMargin(margin_size)
         self.document().rootFrame().setFrameFormat(format)
-
-    def leaveEvent(self, e:QtCore.QEvent) -> None:
-        super().leaveEvent(e)
-        self._entry_file.save(self.toPlainText())

--- a/src/main/python/EditPane.py
+++ b/src/main/python/EditPane.py
@@ -23,7 +23,6 @@ from datetime import date
 import enchant
 import regex
 from enchant.tokenize import get_tokenizer
-import shutil
 import pathlib
 import CONSTANTS
 
@@ -173,8 +172,8 @@ class EditPane(QtWidgets.QTextEdit):
         image_dialog.exec()
         if len(image_dialog.selectedFiles()) > 0:
             image = image_dialog.selectedFiles()[0]
-            shutil.copy(image, pathlib.Path(self.current_file).parent)
-            self.insertPlainText(f"![]({pathlib.Path(image).name})")
+            relative_path = self._entry_file.copy_image(image)
+            self.insertPlainText(f"![]({relative_path})")
 
     def insert_table(self, table: list[list[str]], type: int, include_headers: bool):
         """Insert a table based off a given list of lists of text edits [row][col] and the type of table

--- a/src/main/python/EntryExplorer.py
+++ b/src/main/python/EntryExplorer.py
@@ -17,10 +17,7 @@
 from PyQt6 import QtGui, QtWidgets, QtCore
 from EditPane import EditPane
 from WebView import WebView
-import datetime
 import calendar
-import os
-import json
 
 class EntryExplorer(QtWidgets.QWidget):
     def __init__(self, edit_pane, web_view):

--- a/src/main/python/EntryFile.py
+++ b/src/main/python/EntryFile.py
@@ -2,6 +2,7 @@ from datetime import date
 from genericpath import exists
 import json
 import locale
+import shutil
 import num2words
 import os
 import pathlib
@@ -45,11 +46,12 @@ class EntryFile():
 
     @property
     def directory(self):
-        """Returns current file path"""
+        """The path to the directory of the entry file"""
         return self._directory
 
     @property
     def path(self):
+        """The full path to the entry file"""
         return os.path.join(self._directory, f"{self._formatted_date}.md")
 
 
@@ -111,6 +113,11 @@ class EntryFile():
                 return meta_dict["tags"]
         except Exception:
             return {}
+
+    def copy_image(self, image_path):
+        """Copies the image to the local diary entry folder and returns the relative path to the copy"""
+        shutil.copy(image_path, self._directory)
+        return "./" + pathlib.Path(image_path).name
 
 def get_all_entry_files():
     with open(get_resource("config.json"), "r") as file:

--- a/src/main/python/EntryFile.py
+++ b/src/main/python/EntryFile.py
@@ -1,0 +1,124 @@
+from datetime import date
+from genericpath import exists
+import json
+import locale
+import num2words
+import os
+import pathlib
+import regex
+import yaml
+
+from CONSTANTS import get_resource
+
+
+class EntryFile():
+    def __init__(self, file_date: date = None) -> None:
+
+        if file_date is None:
+            self._formatted_date = ""
+            self._directory = ""
+            self._long_date = ""
+            return
+
+        self._formatted_date = file_date.strftime("%Y-%m-%d")
+        
+        config_file = get_resource("config.json")
+        with open(config_file, "r") as file:
+            diary_directory = json.loads(file.read())["diary_directory"]
+            month_directory = os.path.join(diary_directory, str(file_date.year), f"{file_date.month:02}")
+        
+        self._directory = os.path.join(month_directory, self._formatted_date)
+        
+         # Backward compatibility with v1.1.1 and before: Consider directory without zero filled months
+        if not os.path.exists(self._directory):
+            back_compat_directory = os.path.join(diary_directory, str(file_date.year), str(file_date.month))
+            if os.path.exists(back_compat_directory):
+                self._directory = os.path.join(back_compat_directory, self._formatted_date)
+
+         # Add ordinal to end of number if it exists
+        try:
+            day_of_month = num2words(file_date.day, to="ordinal_num", lang=locale.getlocale()[0])
+        except (NotImplementedError, TypeError):
+            day_of_month = file_date.day
+        self._long_date = file_date.strftime(f"%A {day_of_month} %B %Y")
+
+
+    @property
+    def directory(self):
+        """Returns current file path"""
+        return self._directory
+
+    @property
+    def path(self):
+        return os.path.join(self._directory, f"{self._formatted_date}.md")
+
+
+    @property
+    def formatted_date(self):
+        return self._formatted_date
+
+    @property
+    def long_date(self):
+        return self._long_date
+
+    def get_header_text(self):
+        return '---\n'\
+        f'title: {self._long_date}\n'\
+        f'date: {self._formatted_date}\n'\
+        'tags: []\n'\
+        '---\n'
+
+    def get_content(self):
+        if not self.exists():
+            return ""
+
+        with open(self.path, "r+") as file:
+                return file.read()
+
+    def directory_exists(self):
+        if self._directory == "":
+            return False
+        return os.path.exists(self._directory)
+
+    def exists(self):
+        if not self.directory_exists():
+            return False
+        return os.path.exists(self.path)
+
+    def create_directory(self):
+         pathlib.Path(self._directory).mkdir(parents=True, exist_ok=True)
+
+    def save(self, content: str):
+        if content == self.get_header_text():
+            # No content in the entry except the header text => No save required
+            return
+
+        if not self.directory_exists():
+            self.create_directory()
+        
+        with open(self.path, "w+") as file:
+            file.write(content)
+
+    def get_tags(self):
+        content = self.get_content()
+
+        try:
+            pattern = regex.compile(r"(?<=(^-{3,}\n)).+?(?=-{3,})", regex.DOTALL)
+            metadata = regex.search(pattern, content)
+            if metadata is not None:
+                meta_dict = yaml.safe_load(metadata.group())
+            if "tags" in meta_dict.keys():
+                return meta_dict["tags"]
+        except Exception:
+            return {}
+
+def get_all_entry_files():
+    with open(get_resource("config.json"), "r") as file:
+        directory = json.loads(file.read())["diary_directory"]
+    return list(pathlib.Path(directory).rglob("*-*-*.[mM][dD]"))
+
+def get_all_entry_files_in_range(startdate: date, enddate: date):
+    diary_entries = get_all_entry_files()
+    diary_entries = [entry for entry in diary_entries
+                            if startdate.strftime("%Y-%m-%d") <= entry.name[:-3] <= enddate.strftime("%Y-%m-%d")]
+    return diary_entries

--- a/src/main/python/ExportWindow.py
+++ b/src/main/python/ExportWindow.py
@@ -22,7 +22,7 @@ from threading import Thread
 
 from PyQt6 import QtWidgets, QtGui, QtCore
 from EditPane import EditPane
-from datetime import date
+from datetime import date, datetime
 
 from CONSTANTS import get_resource
 from ColorParser import *
@@ -33,6 +33,7 @@ import os
 import sys
 import CONSTANTS
 import shutil
+import EntryFile
 
 if typing.TYPE_CHECKING:
     pass
@@ -217,12 +218,13 @@ class ExportWindow(QtWidgets.QWidget):
 
         # Custom Range
         if self.date_options.currentText() == "Custom Range":
-            diary_entries = [entry for entry in diary_entries
-                             if self.start_date_widget.date().toString("yyyy-MM-dd") <= entry.name[:-3] <= self.end_date_widget.date().toString("yyyy-MM-dd")]
-
+            diary_entries = EntryFile.get_all_entry_files_in_range(self.start_date_widget.date().toPyDate(), self.end_date_widget.date().toPyDate())
         # Current Date
-        if self.date_options.currentText() == "Current Entry":
-            diary_entries = list(Path(directory).rglob(f"{self.edit_pane.current_file_date}.[mM][dD]"))
+        elif self.date_options.currentText() == "Current Entry":
+            current_date = datetime.strptime(self.edit_pane.current_file_date, "%Y-%m-%d")
+            diary_entries = EntryFile.get_all_entry_files_in_range(current_date, current_date)
+        else:
+            diary_entries = EntryFile.get_all_entry_files()
 
         format = self.output_formats[self.export_options.currentText()]
 

--- a/src/main/python/MainWindow.py
+++ b/src/main/python/MainWindow.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import os
-import pathlib
 import sys
 import typing
 from datetime import date

--- a/src/main/python/MainWindow.py
+++ b/src/main/python/MainWindow.py
@@ -108,7 +108,7 @@ class MainWindow(QtWidgets.QWidget):
             if sys.platform.startswith("linux"):
                 config_dict["diary_directory"] = file_dialog.getExistingDirectory(self,
                                                         "Please select a directory to store your journal files",
-                                                        "", QtWidgets.QFileDialog.ShowDirsOnly | QtWidgets.QFileDialog.DontUseNativeDialog)
+                                                        "", QtWidgets.QFileDialog.Option.ShowDirsOnly | QtWidgets.QFileDialog.Option.DontUseNativeDialog)
             else:
                 config_dict["diary_directory"] = file_dialog.getExistingDirectory(self,
                                                                                   "Please select a directory to store your journal files",

--- a/src/main/python/SettingsWindow.py
+++ b/src/main/python/SettingsWindow.py
@@ -78,11 +78,21 @@ class SettingsWindow(QtWidgets.QWidget):
             config_dict = json.loads(file.read())
             self.spell_checkbox.setCheckState(QtCore.Qt.CheckState.Unchecked if not config_dict["enable_dict"] else QtCore.Qt.CheckState.Checked)
 
+        self.flat_structure_checkbox = QtWidgets.QCheckBox()
+        with open(get_resource("config.json"), "r") as file:
+            config_dict = json.loads(file.read())
+            check_state = QtCore.Qt.CheckState.Unchecked
+            if ("use_flat_directory_structure" in config_dict) and config_dict["use_flat_directory_structure"]:
+                check_state = QtCore.Qt.CheckState.Checked
+            self.flat_structure_checkbox.setCheckState(check_state)
+
         self.spell_checkbox.stateChanged.connect(self.change_spellcheck)
+        self.flat_structure_checkbox.stateChanged.connect(self.change_flat_structure)
         settings_label = QtWidgets.QLabel("Settings")
         settings_label.setStyleSheet("font-size: 16px; font-weight: bold;")
         formLayout.addRow(settings_label)
         formLayout.addRow(QtWidgets.QLabel("Enable spell checker: "), self.spell_checkbox)
+        formLayout.addRow(QtWidgets.QLabel("Use flat directory structure: "), self.flat_structure_checkbox)
 
         self.setLayout(formLayout)
 
@@ -101,6 +111,18 @@ class SettingsWindow(QtWidgets.QWidget):
         with open(get_resource("config.json"), "r+") as file:
             config_dict = json.loads(file.read())
             config_dict["enable_dict"] = True if state == CHECKED else False
+
+            # Write changes and refresh icon
+            file.seek(0)
+            file.write(json.dumps(config_dict, sort_keys=True, indent=4))
+            file.truncate()
+
+    def change_flat_structure(self, state):
+        CHECKED = 2
+        # save state
+        with open(get_resource("config.json"), "r+") as file:
+            config_dict = json.loads(file.read())
+            config_dict["use_flat_directory_structure"] = True if state == CHECKED else False
 
             # Write changes and refresh icon
             file.seek(0)

--- a/src/main/python/WebView.py
+++ b/src/main/python/WebView.py
@@ -25,8 +25,6 @@ from CONSTANTS import get_resource
 import pypandoc
 from EditPane import EditPane
 from ColorParser import parse_stylesheet
-import pathlib
-import os
 
 if typing.TYPE_CHECKING:
     from main import AppContext


### PR DESCRIPTION
Hello,

I did a little refactoring and added some features.The main changes are as following:

1. I moved all file access and file name operations for the diary entries to the class EntryFile to keep them in one single place.
2. Diary entry files are only created if they have real content (and not only the header). This prevents creating "empty" files when clicking in a calendar cell without editing the text.
3. As I found saving the text to a file at every key press too frequently, it is now called whenever the mouse leaves the EditPane (leaveEvent).
4. In the settings the user can choose that the diary entries are stored in a flat file structure: All new files are then created in the year folder of the diary directory and images are placed in the common subdirectory 'images'. If the option is not selected, the file structure is as before. In both cases existing diary entries are not touched and shown correctly in the calendar view.

Feel free to ask in case of any questions.

Best regards!
