### PR TITLE
Add encryption feature

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyQt6
 PyQt6-WebEngine
 pyYAML
 pyobjc-framework-Cocoa; sys_platform == "darwin"
+cryptography

--- a/src/main/python/CalendarFileSelector.py
+++ b/src/main/python/CalendarFileSelector.py
@@ -198,4 +198,15 @@ class CalendarFileSelector(QtWidgets.QCalendarWidget):
         painter.setBackground(brush)
         painter.setBackgroundMode(QtCore.Qt.BGMode.OpaqueMode)
         painter.drawText(rect, QtCore.Qt.AlignmentFlag.AlignBottom | QtCore.Qt.AlignmentFlag.AlignHCenter, text)
+
+        if entry_file.is_encrypted():
+            # Draw a little lock symbol
+            painter.setPen(QtGui.QColor.fromRgb(255, 130, 0))
+            o = QtCore.QPoint(rect.x() + 77, rect.y() + 3)
+            r = QtCore.QRect(o.x(), o.y(), 8, 8)
+            painter.drawEllipse(QtCore.QPoint(o.x()+4, o.y()), 3, 3)
+            painter.fillRect(r, QtGui.QColor().fromRgb(255, 130, 0))
+            painter.setPen(QtGui.QColor.fromRgb(150, 50, 0))
+            painter.drawLine(o.x()+4, o.y()+3, o.x()+4, o.y()+5)
+        
         painter.restore()

--- a/src/main/python/Crypto.py
+++ b/src/main/python/Crypto.py
@@ -9,26 +9,31 @@ class Crypto:
 
     _key = None
     
+
     def __init__(self, password = None):
         if Crypto._key == None and password:
             Crypto._key = self.__generateKeyFromPassword(password)
 
-    @property
+
     def is_initialized(self):
         return not Crypto._key == None
+
 
     def encrypt(self, text: str) -> str:
         crypted_text = Fernet(Crypto._key).encrypt(text.encode())
         return base64.urlsafe_b64encode(crypted_text).decode()
 
+
     def decrypt(self, text: str):
         return Fernet(self._key).decrypt(base64.urlsafe_b64decode(text)).decode()
+
 
     def __generateKeyFromPassword(self, password: str):
         # Always the same salt that only the password is used as input for encryption key
         salt = b'y\x01\x9e\x02\x13\xa93\x13;u6\xcc\xef\xad\xc1\x92'
         kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=100000, backend=default_backend())
-        return kdf.derive(password.encode())
+        return base64.urlsafe_b64encode(kdf.derive(password.encode()))
+
 
 def generateVerificationStringFromPassword(password: str):
     digest = hashes.Hash(hashes.SHA1(), backend=default_backend())

--- a/src/main/python/Crypto.py
+++ b/src/main/python/Crypto.py
@@ -1,0 +1,32 @@
+import os
+from cryptography.fernet import Fernet
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+import base64
+
+class Crypto:
+
+    _key = None
+    
+    def __init__(self, password = None):
+        if Crypto._key == None and password:
+            Crypto._key = self.__generateKeyFromPassword(password)
+
+    def encrypt(self, text: str) -> str:
+        crypted_text = Fernet(Crypto._key).encrypt(text.encode())
+        return base64.urlsafe_b64encode(crypted_text).decode()
+
+    def decrypt(self, text: str):
+        return Fernet(self._key).decrypt(base64.urlsafe_b64decode(text)).decode()
+
+    def __generateKeyFromPassword(self, password: str):
+        # Always the same salt that only the password is used as input for encryption key
+        salt = b'y\x01\x9e\x02\x13\xa93\x13;u6\xcc\xef\xad\xc1\x92'
+        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=100000, backend=default_backend())
+        return kdf.derive(password.encode())
+
+def generateVerificationStringFromPassword(password: str):
+    digest = hashes.Hash(hashes.SHA1(), backend=default_backend())
+    digest.update(password.encode())
+    return base64.urlsafe_b64encode(digest.finalize()).decode()

--- a/src/main/python/Crypto.py
+++ b/src/main/python/Crypto.py
@@ -12,7 +12,7 @@ class Crypto:
 
     def __init__(self, password = None):
         if Crypto._key == None and password:
-            Crypto._key = self.__generateKeyFromPassword(password)
+            Crypto._key = generateKeyFromPassword(password)
 
 
     def is_initialized(self):
@@ -32,14 +32,15 @@ class Crypto:
         return Fernet(self._key).decrypt(base64.urlsafe_b64decode(text)).decode()
 
 
-    def __generateKeyFromPassword(self, password: str):
-        # Always the same salt that only the password is used as input for encryption key
-        salt = b'y\x01\x9e\x02\x13\xa93\x13;u6\xcc\xef\xad\xc1\x92'
-        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=100000, backend=default_backend())
-        return base64.urlsafe_b64encode(kdf.derive(password.encode()))
+def generateKeyFromPassword(password: str):
+    # Always the same salt that only the password is used as input for encryption key
+    salt = b'y\x01\x9e\x02\x13\xa93\x13;u6\xcc\xef\xad\xc1\x92'
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=100000, backend=default_backend())
+    return base64.urlsafe_b64encode(kdf.derive(password.encode()))
 
 
 def generateVerificationStringFromPassword(password: str):
-    digest = hashes.Hash(hashes.SHA1(), backend=default_backend())
-    digest.update(password.encode())
+    key = generateKeyFromPassword(password)
+    digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+    digest.update(key)
     return base64.urlsafe_b64encode(digest.finalize()).decode()

--- a/src/main/python/Crypto.py
+++ b/src/main/python/Crypto.py
@@ -19,6 +19,10 @@ class Crypto:
         return not Crypto._key == None
 
 
+    def uninitialize(self):
+        Crypto._key = None
+
+
     def encrypt(self, text: str) -> str:
         crypted_text = Fernet(Crypto._key).encrypt(text.encode())
         return base64.urlsafe_b64encode(crypted_text).decode()

--- a/src/main/python/Crypto.py
+++ b/src/main/python/Crypto.py
@@ -13,6 +13,10 @@ class Crypto:
         if Crypto._key == None and password:
             Crypto._key = self.__generateKeyFromPassword(password)
 
+    @property
+    def is_initialized(self):
+        return not Crypto._key == None
+
     def encrypt(self, text: str) -> str:
         crypted_text = Fernet(Crypto._key).encrypt(text.encode())
         return base64.urlsafe_b64encode(crypted_text).decode()

--- a/src/main/python/CustomToolbar.py
+++ b/src/main/python/CustomToolbar.py
@@ -32,7 +32,9 @@ from ColorParser import parse_stylesheet
 if typing.TYPE_CHECKING:
     pass
 
+from Crypto import Crypto
 from EditPane import EditPane
+from EntryFile import EntryFile
 from ExportWindow import ExportWindow
 from TableWindow import TableWindow
 from SettingsWindow import SettingsWindow
@@ -72,6 +74,7 @@ class CustomToolbar(QtWidgets.QToolBar):
         self.setToolTip("Favourite")
         self.favorite_button.clicked.connect(self.favorite_clicked)
 
+        # Changedir button
         self.changedir_button = QtWidgets.QPushButton()
         self.changedir_button.setMinimumSize(32, 32)
         self.changedir_button.setMaximumSize(32, 32)
@@ -120,18 +123,27 @@ class CustomToolbar(QtWidgets.QToolBar):
         self.settings_button.setToolTip("Settings")
         self.settings_button.clicked.connect(self.settings_clicked)
 
-
         # Theme switch button
         self.theme_switch_button = QtWidgets.QPushButton()
         self.theme_switch_button.setMinimumSize(32, 32)
         self.theme_switch_button.setMaximumSize(32, 32)
         self.theme_switch_button.setToolTip("Change theme")
-        self.theme_switch_button.clicked.connect(self.theme_switch)
+        self.theme_switch_button.clicked.connect(self.theme_switch_clicked)
+
+         # Encryption switch button
+        self.encryption_switch_button = QtWidgets.QPushButton()
+        self.encryption_switch_button.setText("CRYPT")
+        self.encryption_switch_button.setMinimumSize(32, 32)
+        self.encryption_switch_button.setMaximumSize(32, 32)
+        self.encryption_switch_button.setToolTip("Change encryption")
+        self.encryption_switch_button.clicked.connect(self.encryption_switch_clicked)
+
         #Read current theme
 
         # Add buttons to layout
         self.addWidget(self.open_entry_button)
         self.addWidget(self.favorite_button)
+        self.addWidget(self.encryption_switch_button)
         self.addWidget(self.changedir_button)
         self.addWidget(self.export_button)
         self.font_label = QtWidgets.QLabel("Font size: ")
@@ -147,6 +159,7 @@ class CustomToolbar(QtWidgets.QToolBar):
         self.addWidget(self.preview_button)
         self.addWidget(self.settings_button)
         self.refresh_stylesheet()
+        self.refesh_encryption_switch_button()
 
     def changeEvent(self, event:QtCore.QEvent) -> None:
         # Change button icons to match theme
@@ -185,6 +198,10 @@ class CustomToolbar(QtWidgets.QToolBar):
             file.seek(0)
             file.write(json.dumps(config_dict, sort_keys=True, indent=4))
             file.truncate()
+
+    def entry_file_changed(self):
+       self.refesh_encryption_switch_button()
+
 
     def open_entry_clicked(self):
         """Open calendar dialog and disable main window"""
@@ -261,9 +278,7 @@ class CustomToolbar(QtWidgets.QToolBar):
                                     self.table_option_dialog.include_headers.isChecked())
         self.table_option_dialog.close()
 
-    def theme_switch(self):
-
-
+    def theme_switch_clicked(self):
         current_theme = CONSTANTS.theme
 
         if current_theme == "light":
@@ -298,7 +313,33 @@ class CustomToolbar(QtWidgets.QToolBar):
         self.window().setFocusProxy(self.settings_window)
         self.settings_window.setFocusPolicy(QtCore.Qt.FocusPolicy.StrongFocus)
 
-        self.settings_window.show()
+        self.settings_window.exec()
+
+        # Refresh entry_file as file name might be changed
+        self.edit_pane._entry_file.update()
+        self.refesh_encryption_switch_button()
+
+    def encryption_switch_clicked(self):
+        if self.edit_pane._entry_file.is_encrypted():
+            self.edit_pane._entry_file.set_to_unencrypted()
+        else:
+            self.edit_pane._entry_file.set_to_encrypted()
+
+        self.refesh_encryption_switch_button()
+
+    def refesh_encryption_switch_button(self):
+        c = Crypto()
+        if not c.is_initialized():
+            self.encryption_switch_button.setText("MD")
+            self.encryption_switch_button.setEnabled(False)
+            return
+
+        self.encryption_switch_button.setEnabled(True)
+
+        if self.edit_pane._entry_file.is_encrypted():
+             self.encryption_switch_button.setText("CRYPT")
+        else:
+             self.encryption_switch_button.setText("MD")
 
     def refresh_stylesheet(self):
         self.setStyleSheet("""

--- a/src/main/python/CustomToolbar.py
+++ b/src/main/python/CustomToolbar.py
@@ -132,9 +132,9 @@ class CustomToolbar(QtWidgets.QToolBar):
 
          # Encryption switch button
         self.encryption_switch_button = QtWidgets.QPushButton()
-        self.encryption_switch_button.setText("CRYPT")
         self.encryption_switch_button.setMinimumSize(32, 32)
         self.encryption_switch_button.setMaximumSize(32, 32)
+        self.encryption_switch_button.setIcon(QtGui.QIcon(get_resource(CONSTANTS.icons["unencrypted"][CONSTANTS.theme])))
         self.encryption_switch_button.setToolTip("Change encryption")
         self.encryption_switch_button.clicked.connect(self.encryption_switch_clicked)
 
@@ -179,6 +179,7 @@ class CustomToolbar(QtWidgets.QToolBar):
             self.settings_button.setIcon(QtGui.QIcon(get_resource(CONSTANTS.icons["settings"][CONSTANTS.theme])))
             if sys.platform == "win32":
                 self.font_spinbox.setStyleSheet("color: black;")
+            self.refesh_encryption_switch_button()
 
     def font_change(self, i):
         # Change font
@@ -330,16 +331,16 @@ class CustomToolbar(QtWidgets.QToolBar):
     def refesh_encryption_switch_button(self):
         c = Crypto()
         if not c.is_initialized():
-            self.encryption_switch_button.setText("MD")
+            self.encryption_switch_button.setIcon(QtGui.QIcon(get_resource(CONSTANTS.icons["unencrypted"][CONSTANTS.theme])))
             self.encryption_switch_button.setEnabled(False)
             return
 
         self.encryption_switch_button.setEnabled(True)
 
         if self.edit_pane._entry_file.is_encrypted():
-             self.encryption_switch_button.setText("CRYPT")
+            self.encryption_switch_button.setIcon(QtGui.QIcon(get_resource(CONSTANTS.icons["encrypted"][CONSTANTS.theme])))
         else:
-             self.encryption_switch_button.setText("MD")
+            self.encryption_switch_button.setIcon(QtGui.QIcon(get_resource(CONSTANTS.icons["unencrypted"][CONSTANTS.theme])))
 
     def refresh_stylesheet(self):
         self.setStyleSheet("""

--- a/src/main/python/EditPane.py
+++ b/src/main/python/EditPane.py
@@ -124,6 +124,8 @@ class EditPane(QtWidgets.QTextEdit):
             except KeyError:
                 # Font size not in config
                 self.parent().tool_bar.font_spinbox.setValue(int(self.fontPointSize()))
+
+        self.parent().tool_bar.entry_file_changed()
         
     def keyReleaseEvent(self, e: QtGui.QKeyEvent) -> None:
         """"Override base QTextEdit method, called when key is released

--- a/src/main/python/EntryFile.py
+++ b/src/main/python/EntryFile.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime
 from genericpath import exists
 import json
 import locale
@@ -8,6 +8,7 @@ import os
 import pathlib
 import regex
 import yaml
+from Crypto import Crypto
 
 from CONSTANTS import get_resource
 
@@ -15,12 +16,16 @@ from CONSTANTS import get_resource
 class EntryFile():
     def __init__(self, file_date: date = None) -> None:
 
+        self._crypto = Crypto()
         if file_date is None:
             self._formatted_date = ""
+            self._date = None
             self._directory = ""
             self._long_date = ""
+            self._filename = ""
             return
 
+        self._date = file_date
         self._formatted_date = file_date.strftime("%Y-%m-%d")
         
         config_file = get_resource("config.json")
@@ -28,6 +33,7 @@ class EntryFile():
             config_dict = json.loads(file.read())
             diary_directory = config_dict["diary_directory"]
             self._flat_structure = ("use_flat_directory_structure" in config_dict) and config_dict["use_flat_directory_structure"]
+            encryption_default = ("encrypt_as_default" in config_dict) and config_dict["encrypt_as_default"]
         
         month_directory = os.path.join(diary_directory, str(file_date.year), f"{file_date.month:02}")
         
@@ -39,20 +45,24 @@ class EntryFile():
             if os.path.exists(back_compat_directory):
                 self._directory = os.path.join(back_compat_directory, self._formatted_date)
 
-        if self.exists():
+        self._filename = self.__check_for_existing_filename()
+        if self._filename:
             # File already exists at the default location
             self._flat_structure = False
         else:
             # Check if file already exists with flat directory structure
             default_directory = self._directory
             self._directory = os.path.join(diary_directory, str(file_date.year))
-            if self.exists():
+            self._filename = self.__check_for_existing_filename()
+            if self._filename:
                 self._flat_structure = True
             else:
                 # For a new file select the file location from the settings
                 if self._flat_structure == False:
                     self._directory = default_directory
-
+                self._filename = f"{self._formatted_date}.md"
+                if encryption_default:
+                    self._filename = self._filename + ".crypt"
 
          # Add ordinal to end of number if it exists
         try:
@@ -67,19 +77,89 @@ class EntryFile():
         """The path to the directory of the entry file"""
         return self._directory
 
+
+    @property 
+    def filename(self):
+        """The name of the entry file with extension"""
+        return self._filename
+
+
     @property
     def path(self):
         """The full path to the entry file"""
-        return os.path.join(self._directory, f"{self._formatted_date}.md")
+        return os.path.join(self._directory, self._filename)
 
+
+    @property
+    def date(self):
+        return self._date
 
     @property
     def formatted_date(self):
         return self._formatted_date
 
+
     @property
     def long_date(self):
         return self._long_date
+
+
+    def update(self):
+        self.__init__(self.date)
+
+    def is_encrypted(self):
+        return self._filename.endswith(".crypt")
+
+
+    def set_to_unencrypted(self):
+        if not self.is_encrypted():
+            return
+
+        file_existed = False
+        if self.exists():
+            file_existed = True
+            content = self.get_content()
+            prev_path = self.path
+
+        self._filename = self._filename[:-6]
+       
+        if file_existed:
+            self.save(content)
+            os.remove(prev_path)
+
+
+    def set_to_encrypted(self):
+        if self.is_encrypted():
+            return
+
+        file_existed = False
+        if self.exists():
+            file_existed = True
+            content = self.get_content()
+            prev_path = self.path
+
+        self._filename = self._filename + ".crypt"
+       
+        if file_existed:
+            self.save(content)
+            os.remove(prev_path)
+
+
+    def __check_for_existing_filename(self):
+        if not self.directory_exists():
+            return False
+
+        path = os.path.join(self._directory, f"{self._formatted_date}.md")
+        path_encrypted = os.path.join(self._directory, f"{self._formatted_date}.md.crypt")
+
+        if os.path.exists(path):
+            return f"{self._formatted_date}.md"
+
+        if os.path.exists(path_encrypted):
+            return f"{self._formatted_date}.md.crypt"
+
+        return ""
+
 
     def get_header_text(self):
         return '---\n'\
@@ -88,25 +168,33 @@ class EntryFile():
         'tags: []\n'\
         '---\n'
 
+
     def get_content(self):
         if not self.exists():
             return ""
 
         with open(self.path, "r+") as file:
-                return file.read()
+            content = file.read()
+            if self.is_encrypted():
+                content = self._crypto.decrypt(content)
+            return content
+
 
     def directory_exists(self):
         if self._directory == "":
             return False
         return os.path.exists(self._directory)
 
+
     def exists(self):
         if not self.directory_exists():
             return False
         return os.path.exists(self.path)
 
+
     def create_directory(self):
          pathlib.Path(self._directory).mkdir(parents=True, exist_ok=True)
+
 
     def save(self, content: str):
         if content == self.get_header_text():
@@ -115,9 +203,13 @@ class EntryFile():
 
         if not self.directory_exists():
             self.create_directory()
+
+        if (self.is_encrypted()):
+            content = self._crypto.encrypt(content)
         
         with open(self.path, "w+") as file:
             file.write(content)
+
 
     def get_tags(self):
         content = self.get_content()
@@ -131,6 +223,7 @@ class EntryFile():
                 return meta_dict["tags"]
         except Exception:
             return {}
+
 
     def copy_image(self, image_path):
         """Copies the image to the local diary entry folder and returns the relative path to the copy"""
@@ -151,10 +244,22 @@ class EntryFile():
 def get_all_entry_files():
     with open(get_resource("config.json"), "r") as file:
         directory = json.loads(file.read())["diary_directory"]
-    return list(pathlib.Path(directory).rglob("*-*-*.[mM][dD]"))
+    files = list(pathlib.Path(directory).rglob("*-*-*.[mM][dD]"))
+    files.extend(list(pathlib.Path(directory).rglob("*-*-*.[mM][dD].crypt")))
+
+    ret = list()
+    for file in files:
+        fn = file.name;
+        fn = fn.replace(".crypt", "")
+        fn = fn[:-3]
+        date = datetime.strptime(fn, "%Y-%m-%d");
+        ret.append(EntryFile(date))
+
+    return ret
+
 
 def get_all_entry_files_in_range(startdate: date, enddate: date):
     diary_entries = get_all_entry_files()
     diary_entries = [entry for entry in diary_entries
-                            if startdate.strftime("%Y-%m-%d") <= entry.name[:-3] <= enddate.strftime("%Y-%m-%d")]
+                            if startdate <= entry.date <= enddate]
     return diary_entries

--- a/src/main/python/MainWindow.py
+++ b/src/main/python/MainWindow.py
@@ -87,7 +87,8 @@ class MainWindow(QtWidgets.QWidget):
                     password_ok = True
                 else:
                     QtWidgets.QMessageBox.warning(self, "Error", "Wrong password. Try again.", QtWidgets.QMessageBox.StandardButton.Ok)
-            c = Crypto(password)
+            Crypto(password) # Initialize crypto key
+            
 
         # Layout
         self.layout = QtWidgets.QVBoxLayout(self)

--- a/src/main/python/MainWindow.py
+++ b/src/main/python/MainWindow.py
@@ -27,6 +27,7 @@ from ColorParser import *
 from CustomToolbar import CustomToolbar
 from EditPane import EditPane
 from WebView import WebView
+from Crypto import generateVerificationStringFromPassword, Crypto
 from shutil import which
 from pypandoc.pandoc_download import download_pandoc
 
@@ -74,6 +75,19 @@ class MainWindow(QtWidgets.QWidget):
                 self.select_diary_directory()
             else:
                 exit(0)
+
+        if ("password_hash" in config_dict):
+            password_ok = False
+            while(not password_ok):
+                password, ok = QtWidgets.QInputDialog.getText(self, "Enter Password", "Please enter your encryption password: ", QtWidgets.QLineEdit.EchoMode.Password)
+                if not ok:
+                    exit(0)
+                hash = generateVerificationStringFromPassword(password)
+                if (hash == config_dict["password_hash"]):
+                    password_ok = True
+                else:
+                    QtWidgets.QMessageBox.warning(self, "Error", "Wrong password. Try again.", QtWidgets.QMessageBox.StandardButton.Ok)
+            c = Crypto(password)
 
         # Layout
         self.layout = QtWidgets.QVBoxLayout(self)

--- a/src/main/python/SettingsWindow.py
+++ b/src/main/python/SettingsWindow.py
@@ -84,7 +84,7 @@ class SettingsWindow(QtWidgets.QWidget):
             check_state = QtCore.Qt.CheckState.Unchecked
             if ("use_flat_directory_structure" in config_dict) and config_dict["use_flat_directory_structure"]:
                 check_state = QtCore.Qt.CheckState.Checked
-            self.flat_structure_checkbox.setCheckState(check_state)
+        self.flat_structure_checkbox.setCheckState(check_state)
 
         self.spell_checkbox.stateChanged.connect(self.change_spellcheck)
         self.flat_structure_checkbox.stateChanged.connect(self.change_flat_structure)
@@ -93,7 +93,7 @@ class SettingsWindow(QtWidgets.QWidget):
         formLayout.addRow(settings_label)
         formLayout.addRow(QtWidgets.QLabel("Enable spell checker: "), self.spell_checkbox)
         formLayout.addRow(QtWidgets.QLabel("Use flat directory structure: "), self.flat_structure_checkbox)
-
+       
         self.setLayout(formLayout)
 
 
@@ -185,6 +185,10 @@ that of the main software is listed below.
 
         with open(get_resource("licenses/wkhtmltopdf_license.txt")) as file:
             license_text += "License used by wkhtmltopdf binary <https://github.com/wkhtmltopdf/wkhtmltopdf>\n\n"
+            license_text += file.read() + "\n\n=============================================================================\n\n"
+
+        with open(get_resource("licenses/cryptography_license.txt")) as file:
+            license_text += "License used by python library cryptography <https://github.com/pyca/cryptography>\n\n"
             license_text += file.read() + "\n\n=============================================================================\n\n"
 
         self.license_window.setText(license_text)

--- a/src/main/python/SettingsWindow.py
+++ b/src/main/python/SettingsWindow.py
@@ -172,7 +172,7 @@ class SettingsWindow(QtWidgets.QDialog):
         if not ok or not password:
             return
 
-        password_repeat, ok = QtWidgets.QInputDialog.getText(self, "Repeat Password", "Reapeat password: ", QtWidgets.QLineEdit.EchoMode.Password)
+        password_repeat, ok = QtWidgets.QInputDialog.getText(self, "Repeat Password", "Repeat password: ", QtWidgets.QLineEdit.EchoMode.Password)
         if not ok or not password_repeat:
             return
        

--- a/src/main/python/WebView.py
+++ b/src/main/python/WebView.py
@@ -48,7 +48,7 @@ class WebView(QtWebEngineWidgets.QWebEngineView):
         """Open links in browser
         :param url: Url of file
         """
-        if url.path()[-3:] != ".md":
+        if url.path()[-3:] != ".md" and url.path()[-6:] != ".crypt":
 
             self.back()
             QtGui.QDesktopServices.openUrl(url)

--- a/src/main/resources/base/icons.json
+++ b/src/main/resources/base/icons.json
@@ -50,6 +50,13 @@
   "settings": {
     "light": "icons/gear.svg",
     "dark": "icons/gear-white.svg"
+  },
+  "encrypted": {
+    "light": "icons/lock.svg",
+    "dark": "icons/lock-white.svg"
+  },
+  "unencrypted": {
+    "light": "icons/unlock.svg",
+    "dark": "icons/unlock-white.svg"
   }
-
 }

--- a/src/main/resources/base/icons/lock-white.svg
+++ b/src/main/resources/base/icons/lock-white.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-lock" viewBox="0 0 16 16">
+  <path d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2zm3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2zM5 8h6a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1z"/>
+</svg>

--- a/src/main/resources/base/icons/lock.svg
+++ b/src/main/resources/base/icons/lock.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black" class="bi bi-lock" viewBox="0 0 16 16">
+  <path d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2zm3 6V3a3 3 0 0 0-6 0v4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2zM5 8h6a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V9a1 1 0 0 1 1-1z"/>
+</svg>

--- a/src/main/resources/base/icons/unlock-white.svg
+++ b/src/main/resources/base/icons/unlock-white.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" class="bi bi-unlock" viewBox="0 0 16 16">
+  <path d="M11 1a2 2 0 0 0-2 2v4a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h5V3a3 3 0 0 1 6 0v4a.5.5 0 0 1-1 0V3a2 2 0 0 0-2-2zM3 8a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1H3z"/>
+</svg>

--- a/src/main/resources/base/icons/unlock.svg
+++ b/src/main/resources/base/icons/unlock.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black" class="bi bi-unlock" viewBox="0 0 16 16">
+  <path d="M11 1a2 2 0 0 0-2 2v4a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2h5V3a3 3 0 0 1 6 0v4a.5.5 0 0 1-1 0V3a2 2 0 0 0-2-2zM3 8a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V9a1 1 0 0 0-1-1H3z"/>
+</svg>

--- a/src/main/resources/base/licenses/cryptography_license.txt
+++ b/src/main/resources/base/licenses/cryptography_license.txt
@@ -1,0 +1,201 @@
+             Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Usage

- If encryption is not initialized nothing changes and Pepys can be used as normal.
- Encryption can be initialized via the button in the settings window. When initialized the user must enter the password at every start of the program.
- With initialized encryption the user can select via the lock icon at the entry's toolbar if the entry file is stored as a markdown file (.md) or as an encrypted file (.md.crypt).
- In the calendar view a small lock icon marks encrypted entries.
- In the settings window the user can choose to encrypt new entry files as default. Furthermore, there are two button to convert all entry files in the diary directory to encrypted or plain text.
- Encryption can be deactivated again in the settings window: All entry files are converted to plain text and the password request is removed.


## Technical implementation

- Symmectric Fernet encryption from the cryptography library is used for text encryption.
- With the PBKDF2HMAC function the cryptographic key is derived from the password. As encryption should only depend on the password, a fixed salt is used.
- The password is not stored anywhere, but a SHA256 hash of the key is written to the config file to indicate if encryption is enabled and as a check if the password was entered correctly.


## Open issues

- The cryptography library was added to the requirements.txt, but I did not update the file python3-requirements.json. Is this necessary?
- Also, I didn't test if the setups build or work correctly with the new dependency on the library cryptography.