### PR TITLE
Add fulltext search in diary entries

### DIFF
--- a/src/main/python/CalendarFileSelector.py
+++ b/src/main/python/CalendarFileSelector.py
@@ -144,9 +144,6 @@ class CalendarFileSelector(QtWidgets.QCalendarWidget):
         self.web_view.refresh_page()
 
 
-    def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
-        self.edit_pane.parentWidget().tool_bar.setEnabled(True)
-
     def paintCell(self, painter: QtGui.QPainter, rect: QtCore.QRect, date: typing.Union[QtCore.QDate, datetime.date]) -> None:
         painter.save()
         with open(get_resource("config.json")) as file:

--- a/src/main/python/CustomToolbar.py
+++ b/src/main/python/CustomToolbar.py
@@ -206,7 +206,7 @@ class CustomToolbar(QtWidgets.QToolBar):
 
     def open_entry_clicked(self):
         """Open calendar dialog and disable main window"""
-        self.date_dialog = CalendarFileSelector(self.edit_pane, self.web_view)
+        self.date_dialog = EntryExplorer(self.edit_pane, self.web_view)
         self.setEnabled(False)
         self.date_dialog.show()
 

--- a/src/main/python/EntryExplorer.py
+++ b/src/main/python/EntryExplorer.py
@@ -17,9 +17,11 @@
 from PyQt6 import QtGui, QtWidgets, QtCore
 from EditPane import EditPane
 from WebView import WebView
-import calendar
 
-class EntryExplorer(QtWidgets.QWidget):
+from CalendarFileSelector import CalendarFileSelector
+from SearchWidget import SearchWidget
+
+class EntryExplorer(QtWidgets.QTabWidget):
     def __init__(self, edit_pane, web_view):
         """Constructor
         :param edit_pane: EditPane to open the new file in
@@ -29,46 +31,16 @@ class EntryExplorer(QtWidgets.QWidget):
         self.web_view = web_view
         self.setWindowFlag(QtCore.Qt.WindowType.Dialog)
 
-        date = self.edit_pane.current_file_date.split("-")
+        self.setMinimumSize(640, 660)
+        self.setMaximumSize(640, 660)
+        self.setWindowTitle("Entry Explorer")
 
-        self.setSelectedDate(QtCore.QDate(
-            int(date[0]), int(date[1]), int(date[2])
-        ))
+        calendar = CalendarFileSelector(self.edit_pane, self.web_view)
+        search = SearchWidget(self.edit_pane, self.web_view)
+
+        self.addTab(calendar, "Calendar")
+        self.addTab(search, "Search")
 
 
-        self.setMinimumSize(480, 480)
-        self.setMaximumSize(480, 480)
-        self.setWindowTitle("Calendar")
-
-        main_layout = QtWidgets.QVBoxLayout()
-
-        # Year/month select
-        toolbar = QtWidgets.QToolBar()
-        month_combo = QtWidgets.QComboBox()
-        month_combo.addItems(calendar.month_name[1:])
-        month_combo.setCurrentIndex(self.selected_date.month() - 1)
-        year_entry = QtWidgets.QSpinBox()
-        year_entry.setMinimum(0)
-        year_entry.setMaximum(9999)
-        toolbar.addWidget(month_combo)
-        toolbar.addWidget(year_entry)
-
-        # Calendar grid
-        grid_layout = QtWidgets.QGridLayout()
-        cal = calendar.monthcalendar(self.selected_date.year(), self.selected_date.month())
-        for week in range(len(cal)):
-            for day in range(len(cal[week])):
-                print(cal[week][day])
-                button = QtWidgets.QPushButton()
-                button.setContentsMargins(0, 0, 0, 0)
-                button.setText(str(cal[week][day]))
-                grid_layout.addWidget(button, week, day)
-        grid_layout.setSpacing(0)
-
-        main_layout.addWidget(toolbar)
-        main_layout.addLayout(grid_layout)
-
-        self.setLayout(main_layout)
-    def setSelectedDate(self, date: QtCore.QDate):
-        self.selected_date = date
-
+    def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
+        self.edit_pane.parentWidget().tool_bar.setEnabled(True)

--- a/src/main/python/EntryExplorer.py
+++ b/src/main/python/EntryExplorer.py
@@ -35,12 +35,14 @@ class EntryExplorer(QtWidgets.QTabWidget):
         self.setMaximumSize(640, 660)
         self.setWindowTitle("Entry Explorer")
 
-        calendar = CalendarFileSelector(self.edit_pane, self.web_view)
-        search = SearchWidget(self.edit_pane, self.web_view)
+        self.calendar = CalendarFileSelector(self.edit_pane, self.web_view)
+        self.search = SearchWidget(self.edit_pane, self.web_view)
 
-        self.addTab(calendar, "Calendar")
-        self.addTab(search, "Search")
+        self.addTab(self.calendar, "Calendar")
+        self.addTab(self.search, "Search")
 
 
     def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
+        self.search.close()
+        self.calendar.close()
         self.edit_pane.parentWidget().tool_bar.setEnabled(True)

--- a/src/main/python/SearchWidget.py
+++ b/src/main/python/SearchWidget.py
@@ -8,6 +8,63 @@ from EditPane import EditPane
 from WebView import WebView
 from EntryFile import get_all_entry_files
 
+# Backgournd worker class perfoming search
+class SearchWorker(QtCore.QObject):
+    finished = QtCore.pyqtSignal()
+    progress = QtCore.pyqtSignal(int)
+    result_found = QtCore.pyqtSignal(list)
+
+    def __init__(self, searchText):
+        super().__init__()
+        self._searchText = searchText
+        self._is_running = False
+        self._break = False
+
+    def interrupt(self):
+        self._break = True
+
+    def is_running(self):
+        return self._is_running
+
+    def run(self):
+        self._break = False
+        self._is_running = True
+        entry_files = get_all_entry_files()
+        entry_files.sort(key=lambda x: x.formatted_date)
+
+        results = []
+        counter = 0
+        for e in entry_files:
+            if self._break:
+                break
+            counter = counter + 1
+            self.progress.emit(int(counter *100/ len(entry_files)))
+            table_text = self._build_table_text(e.get_content())
+            if table_text:
+                self.result_found.emit([e.formatted_date, table_text])
+
+        self.finished.emit()
+        self._is_running = False
+
+    def _build_table_text(self, entryText):
+        match_positions = [m.start() for m in re.finditer(self._searchText, entryText, re.IGNORECASE)]
+
+        if len(match_positions) == 0:
+            return ""
+
+        pos = match_positions[0]
+
+        end = pos + 78
+        if end >= len(entryText):
+            table_text = entryText[pos:]
+        else:
+            table_text = entryText[pos:end] + "..."
+
+        if len(match_positions) > 1:
+            table_text = table_text + "(and " + str(len(match_positions)-1) + " more)"
+
+        return table_text
+
 
 class SearchWidget(QtWidgets.QWidget):
     def __init__(self, edit_pane: EditPane, web_view: WebView):
@@ -15,16 +72,17 @@ class SearchWidget(QtWidgets.QWidget):
 
         self.edit_pane = edit_pane
         self.web_view = web_view
+        self.worker = None
 
         self.searchText = QtWidgets.QLineEdit(self)
         self.searchText.returnPressed.connect(self.search_clicked)
 
-        searchButton = QtWidgets.QPushButton("Search", self)
-        searchButton.clicked.connect(self.search_clicked)
+        self.searchButton = QtWidgets.QPushButton("Search", self)
+        self.searchButton.clicked.connect(self.search_clicked)
 
         toolbar = QtWidgets.QToolBar(self)
         toolbar.addWidget(self.searchText)
-        toolbar.addWidget(searchButton)
+        toolbar.addWidget(self.searchButton)
 
         self.progress_bar = QtWidgets.QProgressBar()
         self.progress_bar.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -52,53 +110,32 @@ class SearchWidget(QtWidgets.QWidget):
 
 
     def search_clicked(self):
+        if self.worker and self.worker.is_running():
+            self.worker.interrupt()
+            return
+
+        self.progress_bar.setValue(0)
         self.progress_bar.setVisible(True)
 
         if self.searchText.text() == "":
             return
 
-        entry_files = get_all_entry_files()
-        entry_files.sort(key=lambda x: x.formatted_date)
-
-        results = []
-        counter = 0
-        for e in entry_files:
-            counter = counter + 1
-            self.progress_bar.setValue(int(counter *100/ len(entry_files)))
-            table_text = self.build_table_text(e.get_content(), self.searchText.text())
-            if table_text:
-                results.append([e.formatted_date, table_text])
-
         self.table.clearContents()
-        self.table.setRowCount(len(results))
-        counter = 0
-        for r in results:
-            self.table.setItem(counter, 0, QtWidgets.QTableWidgetItem(r[0]),)
-            self.table.setItem(counter, 1, QtWidgets.QTableWidgetItem(r[1]))
-            counter = counter + 1
-        
-        self.progress_bar.setVisible(False)
-        self.table.resizeColumnsToContents()
+        self.table.setRowCount(0)
 
+        # Run search in a background thread
+        self.thread = QtCore.QThread()
+        self.worker = SearchWorker(self.searchText.text())
+        self.worker.moveToThread(self.thread)
+        self.thread.started.connect(self.worker.run)
+        self.worker.finished.connect(self.search_finished)
+        self.worker.finished.connect(self.thread.quit)
+        self.worker.result_found.connect(self.result_found)
+        self.worker.progress.connect(self.update_progress)
+        self.thread.start()
 
-    def build_table_text(self, entryText, searchText):
-        match_positions = [m.start() for m in re.finditer(searchText, entryText, re.IGNORECASE)]
-
-        if len(match_positions) == 0:
-            return ""
-
-        pos = match_positions[0]
-
-        end = pos + 78
-        if end >= len(entryText):
-            table_text = entryText[pos:]
-        else:
-            table_text = entryText[pos:end] + "..."
-
-        if len(match_positions) > 1:
-            table_text = table_text + "(and " + str(len(match_positions)-1) + " more)"
-
-        return table_text
+        self.searchButton.setText("Stop")
+        self.searchText.setEnabled(False)
 
 
     def on_row_selected(self):
@@ -107,6 +144,25 @@ class SearchWidget(QtWidgets.QWidget):
             date = datetime.datetime.strptime(formatted_date, "%Y-%m-%d")
             self.edit_pane.open_file_from_date(date)
             self.web_view.refresh_page()
+
+
+    def update_progress(self, progress):
+        self.progress_bar.setValue(progress)
+
+
+    def result_found(self, result):
+        row_index = self.table.rowCount()
+        self.table.insertRow(row_index)
+        self.table.setItem(row_index, 0, QtWidgets.QTableWidgetItem(result[0]),)
+        self.table.setItem(row_index, 1, QtWidgets.QTableWidgetItem(result[1]))
+        self.table.resizeColumnsToContents()
+
+
+    def search_finished(self):
+        self.progress_bar.setVisible(False)
+        self.searchButton.setText("Search")
+        self.searchText.setEnabled(True)
+
 
     def showEvent(self, e):
         self.searchText.setFocus()

--- a/src/main/python/SearchWidget.py
+++ b/src/main/python/SearchWidget.py
@@ -47,7 +47,8 @@ class SearchWorker(QtCore.QObject):
 
         pos = match_positions[0]
 
-        end = pos + 78
+        max_len = 77
+        end = pos + max_len
         if end >= len(entryText):
             table_text = entryText[pos:]
         else:

--- a/src/main/python/SearchWidget.py
+++ b/src/main/python/SearchWidget.py
@@ -1,0 +1,112 @@
+from asyncio import TimerHandle
+import datetime
+from PyQt6 import QtWidgets, QtCore
+
+import re
+
+from EditPane import EditPane
+from WebView import WebView
+from EntryFile import get_all_entry_files
+
+
+class SearchWidget(QtWidgets.QWidget):
+    def __init__(self, edit_pane: EditPane, web_view: WebView):
+        super().__init__()
+
+        self.edit_pane = edit_pane
+        self.web_view = web_view
+
+        self.searchText = QtWidgets.QLineEdit(self)
+        self.searchText.returnPressed.connect(self.search_clicked)
+
+        searchButton = QtWidgets.QPushButton("Search", self)
+        searchButton.clicked.connect(self.search_clicked)
+
+        toolbar = QtWidgets.QToolBar(self)
+        toolbar.addWidget(self.searchText)
+        toolbar.addWidget(searchButton)
+
+        self.progress_bar = QtWidgets.QProgressBar()
+        self.progress_bar.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.progress_bar.setVisible(False)
+
+        self.table = QtWidgets.QTableWidget(self)
+        self.table.setColumnCount(2)
+        self.table.setHorizontalHeaderLabels(["Date", "Text"])
+        self.table.resizeRowsToContents()
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionBehavior(QtWidgets.QTableView.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(self.table.SelectionMode.SingleSelection)
+        self.table.setEditTriggers(QtWidgets.QTableWidget.EditTrigger.NoEditTriggers)
+        self.table.itemSelectionChanged.connect(self.on_row_selected)
+        self.table.horizontalHeader().setSortIndicatorShown(True)
+        self.table.setSortingEnabled(True)
+        self.table.setSizeAdjustPolicy(QtWidgets.QAbstractScrollArea.SizeAdjustPolicy.AdjustToContentsOnFirstShow)
+        self.table.horizontalHeader().setStretchLastSection(True)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(toolbar)
+        layout.addWidget(self.progress_bar)
+        layout.addWidget(self.table)
+        self.setLayout(layout)
+
+
+    def search_clicked(self):
+        self.progress_bar.setVisible(True)
+
+        if self.searchText.text() == "":
+            return
+
+        entry_files = get_all_entry_files()
+        entry_files.sort(key=lambda x: x.formatted_date)
+
+        results = []
+        counter = 0
+        for e in entry_files:
+            counter = counter + 1
+            self.progress_bar.setValue(int(counter *100/ len(entry_files)))
+            table_text = self.build_table_text(e.get_content(), self.searchText.text())
+            if table_text:
+                results.append([e.formatted_date, table_text])
+
+        self.table.clearContents()
+        self.table.setRowCount(len(results))
+        counter = 0
+        for r in results:
+            self.table.setItem(counter, 0, QtWidgets.QTableWidgetItem(r[0]),)
+            self.table.setItem(counter, 1, QtWidgets.QTableWidgetItem(r[1]))
+            counter = counter + 1
+        
+        self.progress_bar.setVisible(False)
+        self.table.resizeColumnsToContents()
+
+
+    def build_table_text(self, entryText, searchText):
+        match_positions = [m.start() for m in re.finditer(searchText, entryText, re.IGNORECASE)]
+
+        if len(match_positions) == 0:
+            return ""
+
+        pos = match_positions[0]
+
+        end = pos + 78
+        if end >= len(entryText):
+            table_text = entryText[pos:]
+        else:
+            table_text = entryText[pos:end] + "..."
+
+        if len(match_positions) > 1:
+            table_text = table_text + "(and " + str(len(match_positions)-1) + " more)"
+
+        return table_text
+
+
+    def on_row_selected(self):
+        if self.table.selectedItems():
+            formatted_date = self.table.selectedItems()[0].text()
+            date = datetime.datetime.strptime(formatted_date, "%Y-%m-%d")
+            self.edit_pane.open_file_from_date(date)
+            self.web_view.refresh_page()
+
+    def showEvent(self, e):
+        self.searchText.setFocus()

--- a/src/main/python/SearchWidget.py
+++ b/src/main/python/SearchWidget.py
@@ -109,11 +109,11 @@ class SearchWidget(QtWidgets.QWidget):
             self.worker.interrupt()
             return
 
-        self.progress_bar.setValue(0)
-        self.progress_bar.setVisible(True)
-
         if self.searchText.text() == "":
             return
+
+        self.progress_bar.setValue(0)
+        self.progress_bar.setVisible(True)
 
         self.table.clearContents()
         self.table.setRowCount(0)


### PR DESCRIPTION
- The entry explorer serves as a tab container for calendar view and the new search widget.
- In the search widget the user can start a fulltext search (case insensitive), matching diary entries are listed in the table.
- Clicking on the result opens the diary entry.
- Search is performed in a background thread to prevent the GUI from freezing on long searches. The user can break an ongoing search.